### PR TITLE
DT-4989 do not populate unknown lang names from known alt names

### DIFF
--- a/stream/tag_mapper.js
+++ b/stream/tag_mapper.js
@@ -95,15 +95,6 @@ module.exports = function(){
         }
       }
 
-      // push secondary name suggestions to actual name slots if they are free
-      for(var key in aliases) {
-        for(var ali of aliases[key]) {
-          if (!names[key]) {
-            names[key] = ali;
-          }
-        }
-      }
-
       // process names
       var defaultName = names['default'];
 
@@ -124,6 +115,19 @@ module.exports = function(){
       if (namefi && namesv && namedef && namesv === namedef && namefi !== namedef) {
 	// hit to name.default does not understand that it is in swedish, so put fi as default
 	names.default = namefi;
+      }
+
+      // preprocess aliases
+      for(var key in aliases) {
+        for(var ali of aliases[key]) {
+          if (!names[key]) {
+	    if (defaultName) {
+	      names[key] = defaultName;
+	    } else {
+              names[key] = ali;
+	    }
+          }
+        }
       }
 
       for(var prop in names) {


### PR DESCRIPTION
It is best to assume that default name is the best description in all languages, instead of resorting to
more accurately specified alternate language names such as alt_name:sv etc.
Example: search 'Scandic Meilahti' returned alt_name:fi='HUS potilashotelli'.  This PR fixes the error.